### PR TITLE
Controller tests

### DIFF
--- a/src/main/java/cc/chipchop/exception/ControllerExceptionHandler.java
+++ b/src/main/java/cc/chipchop/exception/ControllerExceptionHandler.java
@@ -1,0 +1,21 @@
+package cc.chipchop.exception;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.net.ConnectException;
+import java.sql.SQLException;
+
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+    @ExceptionHandler({DataAccessException.class, SQLException.class, ConnectException.class})
+    public ResponseEntity<String> handleDatabaseDown(Exception e){
+        return new ResponseEntity<>( HttpStatus.SERVICE_UNAVAILABLE );
+    }
+
+
+}

--- a/src/main/java/cc/chipchop/exception/ControllerExceptionHandler.java
+++ b/src/main/java/cc/chipchop/exception/ControllerExceptionHandler.java
@@ -14,7 +14,7 @@ public class ControllerExceptionHandler {
 
     @ExceptionHandler({DataAccessException.class, SQLException.class, ConnectException.class})
     public ResponseEntity<String> handleDatabaseDown(Exception e){
-        return new ResponseEntity<>( HttpStatus.SERVICE_UNAVAILABLE );
+        return new ResponseEntity<>( HttpStatus.INTERNAL_SERVER_ERROR );
     }
 
 

--- a/src/main/java/cc/chipchop/rest/ChipchopRestController.java
+++ b/src/main/java/cc/chipchop/rest/ChipchopRestController.java
@@ -28,7 +28,7 @@ public class ChipchopRestController {
     }
 
     @PostMapping("/users")
-    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(code = HttpStatus.CREATED)
     public void createUser(@RequestBody User user) {
         userService.insert(user);
     }

--- a/src/main/java/cc/chipchop/rest/ChipchopRestController.java
+++ b/src/main/java/cc/chipchop/rest/ChipchopRestController.java
@@ -2,6 +2,7 @@ package cc.chipchop.rest;
 
 import cc.chipchop.entity.User;
 import cc.chipchop.service.UserService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,8 +27,8 @@ public class ChipchopRestController {
         return userService.findById(id);
     }
 
-
     @PostMapping("/users")
+    @ResponseStatus(HttpStatus.CREATED)
     public void createUser(@RequestBody User user) {
         userService.insert(user);
     }

--- a/src/test/java/cc/chipchop/controller/UserRestControllerTest.java
+++ b/src/test/java/cc/chipchop/controller/UserRestControllerTest.java
@@ -1,0 +1,78 @@
+package cc.chipchop.controller;
+
+import cc.chipchop.entity.User;
+import cc.chipchop.rest.ChipchopRestController;
+import cc.chipchop.service.UserService;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ChipchopRestController.class)
+public class UserRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+
+    @Test
+    public void givenGetAllUsers_whenGetAllUsers_thenSucceedWith200() throws Exception {
+        when(userService.findAll()).thenReturn(List.of(
+            new User(1, "one@test.com", "password"),
+            new User(2, "two@test.com", "passdrd"),
+            new User(3, "tree@test.com", "pass")));
+
+        mockMvc.perform(get("/api/users"))
+            .andExpectAll(
+                status().isOk(),
+                content().contentType(MediaType.APPLICATION_JSON),
+                jsonPath("$.size()").value(3),
+                jsonPath("$[0].id").value(1),
+                jsonPath("$[0].email").value("one@test.com"),
+                jsonPath("$[0].password").value("password")
+            );
+
+        verify(userService, times(1)).findAll();
+        verifyNoMoreInteractions(userService);
+    }
+
+    @Test
+    public void givenGetAllUsers_whenUserListIsEmpty_thenReturnEmptyList() throws Exception {
+        when(userService.findAll()).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/users"))
+            .andExpectAll(
+                status().isOk(),
+                content().contentType(MediaType.APPLICATION_JSON),
+                jsonPath("$.length()").value(0)
+            );
+
+        verify(userService, times(1)).findAll();
+        verifyNoMoreInteractions(userService);
+    }
+
+    @Test
+    public void givenGetAllUsers_whenDatabaseIsDown_thenReturn500() throws Exception {
+        when(userService.findAll()).thenThrow(new RuntimeException());
+
+        assertThrows(ServletException.class, () ->
+            mockMvc.perform(get("/api/users")).andReturn()
+        );
+
+        verify(userService, times(1)).findAll();
+    }
+}

--- a/src/test/java/cc/chipchop/controller/UserRestControllerTest.java
+++ b/src/test/java/cc/chipchop/controller/UserRestControllerTest.java
@@ -7,14 +7,19 @@ import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -75,4 +80,48 @@ public class UserRestControllerTest {
 
         verify(userService, times(1)).findAll();
     }
+
+
+    @Test
+    public void givenFindUserById_whenFindExistingUser_thenSucceedWith200() throws Exception {
+        when(userService.findById(1))
+            .thenReturn(Optional.of(new User(1, "bla@testing.com", "supersecret")));
+
+        mockMvc.perform(get("/api/users/{id}", 1))
+            .andExpectAll(
+                status().isOk(),
+                content().contentType(MediaType.APPLICATION_JSON),
+                jsonPath("$.id").value(1),
+                jsonPath("$.email").value("bla@testing.com"),
+                jsonPath("$.password").value("supersecret")
+            )
+            .andReturn();
+
+        verify(userService, times(1)).findById(1);
+        verifyNoMoreInteractions(userService);
+    }
+
+    @Test
+    public void givenFindUserById_whenFindingInvalidUser_thenReturnNotFound404() throws Exception {
+        when(userService.findById(2)).thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));;
+
+        mockMvc.perform(get("/api/users/{id}", 2))
+                .andExpect(status().isNotFound());
+
+        verify(userService, times(1)).findById(2);
+        verifyNoMoreInteractions(userService);
+    }
+
+    @Test
+    public void givenFindUserById_whenDatabaseIsDown_thenReturn500() throws Exception {
+        when(userService.findById(3)).thenThrow(new RuntimeException());
+
+        assertThrows(ServletException.class, () ->
+            mockMvc.perform(get("/api/users/{id}", 3)).andReturn()
+        );
+
+        verify(userService, times(1)).findById(3);
+    }
+
+
 }

--- a/src/test/java/cc/chipchop/controller/UserRestControllerTest.java
+++ b/src/test/java/cc/chipchop/controller/UserRestControllerTest.java
@@ -158,7 +158,7 @@ public class UserRestControllerTest {
         mockMvc.perform(post("/api/users")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dude)))
-            .andExpect(status().isOk());
+            .andExpect(status().isCreated());
 
         verify(userService, times(1)).insert(argThat(user ->
             user.email().equals("dude@test.com") && user.password().equals("java")));


### PR DESCRIPTION
Test for controller level 

Note:
I havent changed the service layer for insert, as whatever I tried it still returned 200

Current method: 
```
    @Transactional
    public void insert(User user) {
        userDao.findByEmail(user.email()).
            ifPresentOrElse(
                u -> {throw new ResponseStatusException(HttpStatus.CONFLICT);},
                () -> userDao.insert(user));
    }
```

All three versions that I ve done still returned 200 on postman, even when I changed the return type on controller from void to `ResponceEntity<Void>` and `ResponceEntity<User>`

Simple try 1
```
    public ResponseEntity<Void> insert(User user) {
        Optional<User> temp = userDao.findByEmail(user.email());
        if (temp.isPresent()){
            throw new ResponseStatusException(HttpStatus.CONFLICT);
        }
        userDao.insert(user);
        return  ResponseEntity.status(HttpStatus.CREATED).build();
    }
```

Try 2
 ```
   public void insert(User user) {
        userDao.findByEmail(user.email()).
            ifPresentOrElse(
                u -> {throw new ResponseStatusException(HttpStatus.CONFLICT);},
                () -> ResponseEntity.status(HttpStatus.CREATED).body(userDao.insert(user)));
    }
```

Try 3 using `.map`
```
    public void insert(User user) {
        userDao.findByEmail(user.email()).
            ifPresentOrElse(
                u -> {throw new ResponseStatusException(HttpStatus.CONFLICT);},
                () -> ResponseEntity.status(HttpStatus.CREATED).body(userDao.insert(user)));
    }
```

I think its something simple and Im missing completely or I went to completly different direction